### PR TITLE
Update example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,13 @@ func ExampleXML() {
     return nil
   })
 
-  ctx, err := xpath.NewContext(doc.DocumentElement())
+  root, err := doc.DocumentElement()
+  if err != nil {
+    log.Printf("Failed to fetch document element: %s", err)
+    return
+  }
+
+  ctx, err := xpath.NewContext(root)
   if err != nil {
     log.Printf("Failed to create xpath context: %s", err)
     return


### PR DESCRIPTION
Result of doc.DocumentElement() cannot be used as argument of
xpath.NewContext because it returns two, a result and an error.