### PR TITLE
Fixes indentation flag isn't used

### DIFF
--- a/dom/node_document.go
+++ b/dom/node_document.go
@@ -133,7 +133,7 @@ func (d *Document) TextContent() string {
 
 // ToString is currently just an alias to Dump(false)
 func (d *Document) ToString(x int, b bool) string {
-	return d.Dump(false)
+	return d.Dump(b)
 }
 
 // ChildNodes returns the document element


### PR DESCRIPTION
This fixes the issue when indentation flag is not used.
See [reference](http://xmlsoft.org/html/libxml-tree.html#xmlDocDumpFormatMemoryEnc) (`format` argument).