### PR TITLE
added support for wrapping processing information nodes to dom.WrapNode

### DIFF
--- a/dom/dom.go
+++ b/dom/dom.go
@@ -66,6 +66,12 @@ func wrapText(n uintptr) *Text {
 	return &txt
 }
 
+func wrapPiNode(n uintptr) *Pi {
+	txt := Pi{}
+	txt.ptr = n
+	return &txt
+}
+
 // WrapNode is a function created with the sole purpose of allowing
 // go-libxml2 consumers that can generate a C.xmlNode pointer to
 // create libxml2.Node types, e.g. go-xmlsec.
@@ -79,6 +85,8 @@ func WrapNode(n uintptr) (types.Node, error) {
 		return wrapText(n), nil
 	case clib.CDataSectionNode:
 		return wrapCDataSection(n), nil
+	case clib.PiNode:
+		return wrapPiNode(n), nil
 	case clib.CommentNode:
 		return wrapComment(n), nil
 	default:

--- a/dom/interface.go
+++ b/dom/interface.go
@@ -51,6 +51,10 @@ type CDataSection struct {
 	XMLNode
 }
 
+type Pi struct {
+	XMLNode
+}
+
 type Comment struct {
 	XMLNode
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -303,3 +303,30 @@ func TestCommentWrapNodeIssue(t *testing.T) {
 		t.Fatalf("HTML did not convert back correctly, expected: %v, got: %v.", testHTML, str)
 	}
 }
+
+func TestPiWrapNodeIssue(t *testing.T) {
+
+	// should wrap Pi node
+	const textXML = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<a>test <?test?></a>\n"
+	doc, err := ParseString(textXML)
+	if err != nil {
+		t.Fatalf("Got error when parsing xml: %v", err)
+	}
+
+	nodes, err := doc.ChildNodes()
+	if err != nil {
+		t.Fatalf("Got error when getting childnodes: %v", err)
+	}
+
+	for _, node := range nodes {
+		if node.HasChildNodes() {
+			if _, err := node.ChildNodes(); err != nil {
+				t.Fatalf("Got error when getting childnodes of childnodes: %v", err)
+			}
+		}
+	}
+
+	if str := doc.String(); str != textXML {
+		t.Fatalf("XML did not convert back correctly, expected: %v, got: %v", textXML, str)
+	}
+}


### PR DESCRIPTION
This PR adds support for Processing Information nodes to `dom.WrapNode` along with test case.