### PR TITLE
Proxy ErrAttributeNotFound from clib for consumers to test against

### DIFF
--- a/clib/clib.go
+++ b/clib/clib.go
@@ -1684,7 +1684,7 @@ func XMLElementGetAttributeNode(n PtrSource, name string) (uintptr, error) {
 	}
 
 	if prop == nil || XMLNodeType(prop._type) != AttributeNode {
-		return 0, errors.New("attribute not found")
+		return 0, ErrAttributeNotFound
 	}
 
 	return uintptr(unsafe.Pointer(prop)), nil

--- a/clib/interface.go
+++ b/clib/interface.go
@@ -54,6 +54,7 @@ const (
 )
 
 var (
+	ErrAttributeNotFound      = errors.New("attribute not found")
 	ErrAttributeNameTooLong   = errors.New("attribute name too long")
 	ErrElementNameTooLong     = errors.New("element name too long")
 	ErrNamespaceURITooLong    = errors.New("namespace uri too long")

--- a/dom/interface.go
+++ b/dom/interface.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	ErrAttributeNotFound = errors.New("attribute not found")
+	ErrAttributeNotFound = clib.ErrAttributeNotFound
 	ErrInvalidNodeType   = errors.New("invalid node type")
 )
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -4,6 +4,9 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/lestrrat/go-libxml2/dom"
+	"github.com/lestrrat/go-libxml2/types"
+
 	"github.com/lestrrat/go-libxml2/clib"
 	"github.com/lestrrat/go-libxml2/parser"
 	"github.com/stretchr/testify/assert"
@@ -328,5 +331,29 @@ func TestPiWrapNodeIssue(t *testing.T) {
 
 	if str := doc.String(); str != textXML {
 		t.Fatalf("XML did not convert back correctly, expected: %v, got: %v", textXML, str)
+	}
+}
+
+func TestGetNonexistentAttributeReturnsRecoverableError(t *testing.T) {
+	const src = `<?xml version="1.0"?><rootnode/>`
+	doc, err := ParseString(src)
+	if !assert.NoError(t, err, "Should parse") {
+		return
+	}
+	defer doc.Free()
+
+	rootNode, err := doc.DocumentElement()
+	if !assert.NoError(t, err, "Should find root element") {
+		return
+	}
+
+	el, ok := rootNode.(types.Element)
+	if !ok {
+		t.Fatalf("Root node was not an element")
+	}
+
+	_, err = el.GetAttribute("non-existant")
+	if err != dom.ErrAttributeNotFound {
+		t.Fatalf("GetAttribute() error not comparable to existing library")
 	}
 }


### PR DESCRIPTION
Right now if you use `element.GetAttribute("some invalid attribute name")`, go-libxml2 will return an error detailing that the attribute was not found.  However, this is not the same error as the one detailed in the `dom` package.

This change moves the error from the `dom` package to the `clib` package where it can be used as part of `GetAttribute` and creates a link in the dom package for existing implementations.  