### PR TITLE
Don't show go:generate comment in documentation

### DIFF
--- a/libxml2.go
+++ b/libxml2.go
@@ -1,6 +1,6 @@
 //go:generate go run internal/cmd/genwrapnode/genwrapnode.go -- dom/node_wrap.go
-/*
 
+/*
 Package libxml2 is an interface to libxml2 library, providing XML and HTML parsers
 with DOM interface. The inspiration is Perl5's XML::LibXML module.
 


### PR DESCRIPTION
Currently, the `go:generate` pragma shows up in the documentation. This PR moves a blank line that appears to have been put in the wrong spot so that the comment doesn't show up on top of the documentation and as the description for the package on GDDO.

![The docs as they appear before this PR on GDDO](https://user-images.githubusercontent.com/512573/29340740-3088988a-81e6-11e7-98ac-246308544a9b.png)

![The description for the package as it appears before this PR on GDDO](https://user-images.githubusercontent.com/512573/29340814-981fbc6c-81e6-11e7-8d4e-0528175f820f.png)
