### PR TITLE
Gutweiler fix memleak

### DIFF
--- a/clib/clib.go
+++ b/clib/clib.go
@@ -847,10 +847,14 @@ func XMLNodeValue(n PtrSource) (string, error) {
 	var s string
 	switch XMLNodeType(nptr._type) {
 	case AttributeNode, ElementNode, TextNode, CommentNode, PiNode, EntityRefNode:
-		s = xmlCharToString(C.xmlXPathCastNodeToString(nptr))
+		xc := C.xmlXPathCastNodeToString(nptr)
+		s = xmlCharToString(xc)
+		C.MY_xmlFree(unsafe.Pointer(xc))
 	case CDataSectionNode, EntityDecl:
 		if nptr.content != nil {
-			s = xmlCharToString(C.xmlStrdup(nptr.content))
+			xc := C.xmlStrdup(nptr.content)
+			s = xmlCharToString(xc)
+			C.MY_xmlFree(unsafe.Pointer(xc))
 		}
 	default:
 		panic("unimplmented")
@@ -1503,6 +1507,7 @@ func XMLDocumentString(doc PtrSource, encoding string, format bool) string {
 	var xc *C.xmlChar
 	C.xmlDocDumpFormatMemoryEnc(dptr, &xc, &i, (*C.char)(unsafe.Pointer(xcencodingptr)), intformat)
 
+	defer C.MY_xmlFree(unsafe.Pointer(xc))
 	return xmlCharToString(xc)
 }
 

--- a/libxml2_bench_test.go
+++ b/libxml2_bench_test.go
@@ -31,7 +31,7 @@ func BenchmarkXmlpathXmlpath(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		p, err := xmlpath.Compile(`//entry`)
 		if err != nil {
-			b.Fatal("%s", err)
+			b.Fatalf("%s", err)
 		}
 		it := p.Iter(root)
 		for it.Next() {
@@ -90,12 +90,12 @@ func BenchmarkLibxml2Xmlpath(b *testing.B) {
 
 	doc, err := libxml2.ParseReader(f)
 	if err != nil {
-		b.Fatal("%s", err)
+		b.Fatalf("%s", err)
 	}
 
 	xpc, err := xpath.NewContext(doc)
 	if err != nil {
-		b.Fatal("%s", err)
+		b.Fatalf("%s", err)
 	}
 	xpc.RegisterNS("atom", "http://www.w3.org/2005/Atom")
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
merge #45, and fix test failures on tip, caused by use of `b.Fatal` in place of `b.Fatalf`